### PR TITLE
ci: add slither

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,25 @@
+name: Slither Analysis
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Slither analysis
+        uses: crytic/slither-action@v0.3.0
+        with:
+          slither-args: --filter-paths "test" --exclude-dependencies
+          fail-on: 'medium'


### PR DESCRIPTION
Add Slither actions to standard strategy GitHub actions checks.

Slither is Solidity static analysis tool: https://github.com/crytic/slither
More info about slither actions: https://github.com/crytic/slither-action/

Specs:
- Run on master and pull requests, the same config as for test actions.
- Use foundry for code compilation.
- Run slither but skip the test folder and dependencies.
- Action will fail if there is a medium-level finding or above.