### PR TITLE
chore: add slither config

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -21,5 +21,4 @@ jobs:
       - name: Slither analysis
         uses: crytic/slither-action@v0.3.0
         with:
-          slither-args: --filter-paths "test" --exclude-dependencies
           fail-on: 'medium'

--- a/README.md
+++ b/README.md
@@ -163,3 +163,11 @@ Once the Strategy is fully deployed and verified, you will need to verify the To
 This should add all of the external `TokenizedStrategy` functions to the contract interface on Etherscan.
 
 See the ApeWorx [documentation](https://docs.apeworx.io/ape/stable/) and [GitHub](https://github.com/ApeWorX/ape) for more information.
+
+## CI
+
+This repo uses [GitHub Actions](.github/workflows) for CI. There are three workflows: lint, test and slither for static analysis.
+
+To enable test workflow you need to add `ETHERSCAN_API_KEY` and `ETH_RPC_URL` secrets to your repo. For more info see [GitHub Actions docs](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-a-repository).
+
+If the slither finds some issues that you want to suppress, before the issue add comment: `//slither-disable-next-line DETECTOR_NAME`. For more info about detectors see [Slither docs](https://github.com/crytic/slither/wiki/Detector-Documentation).

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,4 @@
+{
+    "detectors_to_exclude": "naming-convention",
+    "filter_paths": "(lib/|src/test)"
+}

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-    "detectors_to_exclude": "naming-convention",
+    "detectors_to_exclude": "naming-convention,unused-return",
     "filter_paths": "(lib/|src/test)"
 }


### PR DESCRIPTION
- Add slither config file.
- Exclude `naming-convention` and `unused-return` decorators by default.
- Skip checking dependencies and test folders.

For more info about decorators see: https://github.com/crytic/slither/wiki/Detector-Documentation 