### PR TITLE
chore: bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 .gas-snapshot
 
 yarn.lock
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,11 +5,11 @@
 [submodule "lib/tokenized-strategy"]
 	path = lib/tokenized-strategy
 	url = https://github.com/yearn/tokenized-strategy
-	release = v3.0.2
+	release = v3.0.2-1
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "lib/tokenized-strategy-periphery"]
 	path = lib/tokenized-strategy-periphery
 	url = https://github.com/yearn/tokenized-strategy-periphery
-	branch = master
+	branch = greater_than

--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,7 @@
     "extends": "solhint:recommended",
     "plugins": [],
     "rules": {
-      "compiler-version": ["error", "0.8.23"],
+      "compiler-version": ["error", "^0.8.18"],
       "code-complexity": "warn",
       "const-name-snakecase": "warn",
       "function-max-lines": "warn",

--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,7 @@
     "extends": "solhint:recommended",
     "plugins": [],
     "rules": {
-      "compiler-version": ["error", "0.8.18"],
+      "compiler-version": ["error", "0.8.23"],
       "code-complexity": "warn",
       "const-name-snakecase": "warn",
       "function-max-lines": "warn",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "solidity.compileUsingRemoteVersion": "v0.8.18",
+  "solidity.compileUsingRemoteVersion": "v0.8.23",
   "solidity.remappings": [
     "@openzeppelin/=./lib/openzeppelin-contracts/",
     "forge-std/=lib/forge-std/src/",

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ size  :; forge build --sizes
 # storage inspection
 inspect :; forge inspect ${contract} storage-layout --pretty
 
-FORK_URL := ${ETH_RPC_URL} 
+# specify which fork to use. set this in our .env
+# if we want to test multiple forks in one go, remove this as an argument below
+FORK_URL := ${ETH_RPC_URL} # BASE_RPC_URL, ETH_RPC_URL, ARBITRUM_RPC_URL
+
+# if we want to run only matching tests, set that here
+test := test_
 
 # local tests without fork
 test  :; forge test -vv --fork-url ${FORK_URL}
@@ -18,9 +23,15 @@ test-contract  :; forge test -vv --match-contract $(contract) --fork-url ${FORK_
 test-contract-gas  :; forge test --gas-report --match-contract ${contract} --fork-url ${FORK_URL}
 trace-contract  :; forge test -vvv --match-contract $(contract) --fork-url ${FORK_URL}
 test-test  :; forge test -vv --match-test $(test) --fork-url ${FORK_URL}
-trace-test  :; forge test -vvv --match-test $(test) --fork-url ${FORK_URL}
+test-test-trace  :; forge test -vvv --match-test $(test) --fork-url ${FORK_URL}
+trace-test  :; forge test -vvvvv --match-test $(test) --fork-url ${FORK_URL}
 snapshot :; forge snapshot -vv --fork-url ${FORK_URL}
 snapshot-diff :; forge snapshot --diff -vv --fork-url ${FORK_URL}
+trace-setup  :; forge test -vvvv --fork-url ${FORK_URL}
+trace-max  :; forge test -vvvvv --fork-url ${FORK_URL}
+coverage :; forge coverage --fork-url ${FORK_URL}
+coverage-report :; forge coverage --report lcov --fork-url ${FORK_URL}
+coverage-debug :; forge coverage --report debug --fork-url ${FORK_URL}
 
 
 clean  :; forge clean

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc = "0.8.18"
+solc = "0.8.23"
 
 remappings = [
     "@openzeppelin/=lib/openzeppelin-contracts/",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "prettier": "^2.5.1",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "pretty-quick": "^3.1.3",
-        "solc": "0.8.18",
+        "solc": "0.8.23",
         "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "prettier": "^2.5.1",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "pretty-quick": "^3.1.3",
-        "solc": "0.8.23",
+        "solc": "^0.8.18",
         "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "prettier": "^2.5.1",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "pretty-quick": "^3.1.3",
-        "solc": "^0.8.18",
+        "solc": "0.8.23",
         "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5"
     },

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import {BaseStrategy, ERC20} from "@tokenized-strategy/BaseStrategy.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/interfaces/IStrategyInterface.sol
+++ b/src/interfaces/IStrategyInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 

--- a/src/periphery/StrategyAprOracle.sol
+++ b/src/periphery/StrategyAprOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import {AprOracleBase} from "@periphery/AprOracle/AprOracleBase.sol";
 

--- a/src/test/FunctionSignature.t.sol
+++ b/src/test/FunctionSignature.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "forge-std/console.sol";
+import "forge-std/console2.sol";
 import {Setup, ERC20, IStrategyInterface} from "./utils/Setup.sol";
 
 contract FunctionSignatureTest is Setup {

--- a/src/test/Operation.t.sol
+++ b/src/test/Operation.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "forge-std/console.sol";
+import "forge-std/console2.sol";
 import {Setup, ERC20, IStrategyInterface} from "./utils/Setup.sol";
 
 contract OperationTest is Setup {
@@ -10,7 +10,7 @@ contract OperationTest is Setup {
     }
 
     function test_setupStrategyOK() public {
-        console.log("address of strategy", address(strategy));
+        console2.log("address of strategy", address(strategy));
         assertTrue(address(0) != address(strategy));
         assertEq(strategy.asset(), address(asset));
         assertEq(strategy.management(), management);

--- a/src/test/Oracle.t.sol
+++ b/src/test/Oracle.t.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.18;
 
-import "forge-std/console.sol";
+import "forge-std/console2.sol";
 import {Setup} from "./utils/Setup.sol";
 
 import {StrategyAprOracle} from "../periphery/StrategyAprOracle.sol";

--- a/src/test/Shutdown.t.sol
+++ b/src/test/Shutdown.t.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.18;
 
-import "forge-std/console.sol";
+import "forge-std/console2.sol";
 import {Setup, ERC20, IStrategyInterface} from "./utils/Setup.sol";
 
 contract ShutdownTest is Setup {

--- a/src/test/utils/ExtendedTest.sol
+++ b/src/test/utils/ExtendedTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/src/test/utils/Setup.sol
+++ b/src/test/utils/Setup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import "forge-std/console.sol";
 import {ExtendedTest} from "./ExtendedTest.sol";

--- a/src/test/utils/Setup.sol
+++ b/src/test/utils/Setup.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.18;
 
-import "forge-std/console.sol";
+import "forge-std/console2.sol";
 import {ExtendedTest} from "./ExtendedTest.sol";
 
 import {Strategy, ERC20} from "../../Strategy.sol";


### PR DESCRIPTION
bump to use latest >= tokenized strategy and periphery. set 0.8.23 (last shanghai compiler version) as default for now 