### PR TITLE
ci: add code coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
 
 jobs:
   coverage:
@@ -27,24 +28,11 @@ jobs:
         with:
           version: nightly
 
-      - name: Run Forge build # replace it with download-artifact
-        run: |
-          forge build
-        id: build
-
-      - name: Run Forge coverage
-        run: |
-          forge coverage --report lcov -vvv --fork-url ${{ secrets.ETH_RPC_URL }}
-        id: coverage
-
       - name: Install lcov
         run: sudo apt-get -y install lcov
 
-      - name: Remove test files from coverage data
-        run: lcov --remove lcov.info 'src/test/**' --output-file lcov.info
-
-      - name: Generate coverage report
-        run: genhtml -o coverage-report lcov.info
+      - name: Run generate html report
+        run: make coverage-html
 
       - name: Generate summary report
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,70 @@
+name: coverage
+
+on:
+  push:
+    branches:
+    - master
+    - develop
+  pull_request:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  coverage:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build # replace it with download-artifact
+        run: |
+          forge build
+        id: build
+
+      - name: Run Forge coverage
+        run: |
+          forge coverage --report lcov -vvv --fork-url ${{ secrets.ETH_RPC_URL }}
+        id: coverage
+
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
+
+      - name: Remove test files from coverage data
+        run: lcov --remove lcov.info 'src/test/**' --output-file lcov.info
+
+      - name: Generate coverage report
+        run: genhtml -o coverage-report lcov.info
+
+      - name: Generate summary report
+        run: |
+          lcov --summary lcov.info > coverage-report/summary.md
+          sed -i '1d' coverage-report/summary.md
+          sed -i '/Message summary:/,$d' coverage-report/summary.md
+
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CoverageReport # Artifact name
+          path: coverage-report # Directory containing files to upload
+
+      - name: Add comment to PR
+        if: github.event_name == 'pull_request' && env.GH_TOKEN != ''
+        run: gh pr comment $PR_NUMBER --body-file coverage-report/summary.md
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
+      - name: Publish coverage in build summary
+        run: cat coverage-report/summary.md >> $GITHUB_STEP_SUMMARY
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
+  test:
     strategy:
       fail-fast: true
 

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,16 @@ coverage :; forge coverage --fork-url ${FORK_URL}
 coverage-report :; forge coverage --report lcov --fork-url ${FORK_URL}
 coverage-debug :; forge coverage --report debug --fork-url ${FORK_URL}
 
+coverage-html:
+	@echo "Running coverage..."
+	forge coverage --report lcov --fork-url ${FORK_URL}
+	@if [ "`uname`" = "Darwin" ]; then \
+		lcov --ignore-errors inconsistent --remove lcov.info 'src/test/**' --output-file lcov.info; \
+		genhtml --ignore-errors inconsistent -o coverage-report lcov.info; \
+	else \
+		lcov --remove lcov.info 'src/test/**' --output-file lcov.info; \
+		genhtml -o coverage-report lcov.info; \
+	fi
+	@echo "Coverage report generated at coverage-report/index.html"
 
 clean  :; forge clean

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ NOTE: Compiler defaults to 8.23 but it can be adjusted in the foundry toml.
 
 ## Testing
 
-Due to the nature of the BaseStrategy utilizing an external contract for the majority of its logic, the default interface for any tokenized strategy will not allow proper testing of all functions. Testing of your Strategy should utilize the pre-built [IStrategyInterface](https://github.com/yearn/tokenized-strategy-foundry-mix/blob/master/src/interfaces/IStrategyInterface.sol) to cast any deployed strategy through for testing, as seen in the Setup example. You can add any external functions that you add for your specific strategy to this interface to be able to test all functions with one variable. 
+Due to the nature of the BaseStrategy utilizing an external contract for the majority of its logic, the default interface for any tokenized strategy will not allow proper testing of all functions. Testing of your Strategy should utilize the pre-built [IStrategyInterface](https://github.com/yearn/tokenized-strategy-foundry-mix/blob/master/src/interfaces/IStrategyInterface.sol) to cast any deployed strategy through for testing, as seen in the Setup example. You can add any external functions that you add for your specific strategy to this interface to be able to test all functions with one variable.
 
 Example:
 
@@ -95,6 +95,22 @@ When testing on chains other than mainnet you will need to make sure a valid `CH
 
 To update to a new API version of the TokenizeStrategy you will need to simply remove and reinstall the dependency.
 
+### Test Coverage
+
+Run the following command to generate a test coverage:
+
+```sh
+make coverage
+```
+
+To generate test coverage report in HTML, you need to have installed [`lcov`](https://github.com/linux-test-project/lcov) and run:
+
+```sh
+make coverage-html
+```
+
+The generated report will be in `coverage-report/index.html`.
+
 ### Deployment
 
 #### Contract Verification
@@ -115,3 +131,9 @@ This repo uses [GitHub Actions](.github/workflows) for CI. There are three workf
 To enable test workflow you need to add the `ETH_RPC_URL` secret to your repo. For more info see [GitHub Actions docs](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-a-repository).
 
 If the slither finds some issues that you want to suppress, before the issue add comment: `//slither-disable-next-line DETECTOR_NAME`. For more info about detectors see [Slither docs](https://github.com/crytic/slither/wiki/Detector-Documentation).
+
+### Coverage
+
+If you want to use [`coverage.yml`](.github/workflows/coverage.yml) workflow on other chains than mainnet, you need to add the additional `CHAIN_RPC_URL` secret.
+
+Coverage workflow will generate coverage summary and attach it to PR as a comment. To enable this feature you need to add the [`GH_TOKEN`](.github/workflows/coverage.yml#L53) secret to your Github repo. Token must have permission to "Read and Write access to pull requests". To generate token go to [Github settings page](https://github.com/settings/tokens?type=beta). For more info see [GitHub Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).


### PR DESCRIPTION
Adds Github actions workflow to generate code coverage report and stores it as an artifact.

The flow is following:

- Run `forge coverage --report lcov` to generate the report
- Generate HTML report
- Upload the report to Github actions artifcats
- Publish code coverage data to PR (if PR is used) and `env.GH_TOKEN` is defined in secrets
- Publish coverage in the build summary for faster review

Example of the successful actions: https://github.com/spalen0/tokenized-strategy-foundry-mix/actions/runs/11129598557
