### PR TITLE
ci: bump slither-action from v0.3.0 to v0.4.0

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -19,6 +19,6 @@ jobs:
           version: nightly
 
       - name: Slither analysis
-        uses: crytic/slither-action@v0.3.0
+        uses: crytic/slither-action@v0.4.0
         with:
           fail-on: 'medium'


### PR DESCRIPTION
Bump `crytic/slither-action` version to [latest](https://github.com/crytic/slither-action/releases/tag/v0.4.0).